### PR TITLE
Power estimate: use the imported binary of a version as its base

### DIFF
--- a/src/components/power-estimate-modal.tsx
+++ b/src/components/power-estimate-modal.tsx
@@ -181,9 +181,16 @@ export function PowerEstimateModal({ file, onClose, live, embedded = false, onMi
         const binary = await store.readBinary(file.id);
         if (!binary) throw new Error("no_binary");
 
-        // Reconstruct the selected version: original + binary patches;
-        // map-cell edits are overlaid in display units by the estimator.
-        // The untouched original anchors the injector-flow model.
+        // Reconstruct the selected version: its own base binary + binary
+        // patches; map-cell edits are overlaid in display units by the
+        // estimator. The untouched original anchors the injector-flow model.
+        //
+        // The base is the imported binary of the version when it exists
+        // (`version-<id>.bin`, written by the editor's import), otherwise
+        // the original file — same precedence as buildVersionFileData in the
+        // editor. Before, the non-live path always started from the original,
+        // so an imported version that had not been saved yet (no map edits
+        // persisted) was estimated on the stock file.
         const version = versions.find((v) => v.id === versionId);
         let bytes = binary;
         let edits: Array<{ map_address: number; payload?: any }> = [];
@@ -196,7 +203,15 @@ export function PowerEstimateModal({ file, onClose, live, embedded = false, onMi
           edits = state.edits;
         } else if (version && version.name !== "Ori") {
           edits = await store.listMapEdits(versionId);
-          bytes = new Uint8Array(binary);
+          let base: Uint8Array | null = null;
+          try {
+            base = await store.readVersionBinary(versionId);
+          } catch {
+            // pas de binaire importé pour cette version
+          }
+          bytes = new Uint8Array(
+            base && base.length === binary.length ? base : binary
+          );
           for (const edit of edits) {
             if (edit.map_address === -1 && edit.payload?.type === "binary") {
               for (const c of edit.payload.changes || []) {


### PR DESCRIPTION
The power-estimate modal rebuilt a non-live version as Ori + persisted map edits. A version created by importing a file only writes version-<id>.bin and keeps its modifications in memory until the user saves, so estimating it from the dashboard (or with another version open in the editor) ran on the stock file and showed the stock figures.

Start from readVersionBinary(versionId) when it exists (same precedence as buildVersionFileData in the editor), fall back to the original otherwise. The original still anchors the injector-flow model.